### PR TITLE
Correct primary key for mysql

### DIFF
--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -24,3 +24,10 @@ ALTER TABLE `auth_tokens`
 
 ALTER TABLE `auth_tokens`
     ADD PRIMARY KEY(`token`);
+
+--
+-- Update Version 5.X.0
+-- Issue #36
+--
+ALTER TABLE `auth_tokens` DROP PRIMARY KEY;
+ALTER TABLE `auth_tokens` ADD COLUMN id INT AUTO_INCREMENT PRIMARY KEY;


### PR DESCRIPTION
A primary key needs to be unique!

A token doesn't have to be unique... on a system with thousands of users the random token will some day collide with another existing token, resulting in an error.

Not tested as I'm not using a mysql database. 