### PR TITLE
Add auth_tokens table creation sql for SQLite database

### DIFF
--- a/sql/sqlite.sql
+++ b/sql/sqlite.sql
@@ -1,0 +1,14 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE auth_tokens (
+  id integer PRIMARY KEY AUTOINCREMENT,
+  token varchar(128) DEFAULT '' NOT NULL,
+  expires timestamp with time zone NOT NULL,      
+  user_id integer NOT NULL
+    REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  user_name varchar(128) NOT NULL,
+  user_pass varchar(128) NOT NULL,
+  host varchar(255) NOT NULL
+);
+
+CREATE INDEX token_userid ON auth_tokens (token, user_id);


### PR DESCRIPTION
As the title suggests... SQLite support for auth_tokens with an index for performance reason.

SQLite does have the limitation that 'PRAGMA foreign keys = ON' needs to be set for every session... otherwise the cascaded delete/update doesn't work.

Please consider adding index for other databases (mysql, postgres) too.