### PR TITLE
Secure token

### DIFF
--- a/persistent_login.php
+++ b/persistent_login.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin which provides a persistent login functionality.
- * Also known as "remembery me" or "stay logged in" function.
+ * Also known as "remember me" or "stay logged in" function.
  *
  * @version @package_version@
  * @author insaneFactory, Manuel Freiholz

--- a/persistent_login.php
+++ b/persistent_login.php
@@ -405,17 +405,10 @@ class persistent_login extends rcube_plugin
 	 * @param $len length of the generated random string
 	 * @return string
 	 */
-	function generate_random_token($len = 28)
+	function generate_random_token($len = 32)
 	{
-		$chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-		$min = 0;
-		$max = strlen($chars) - 1;
-
-		$random_string = "";
-		for ($i = 0; $i < $len; ++$i) {
-			$pos = mt_rand($min, $max);
-			$random_string.= substr($chars, $pos, 1);
-		}
+		$rand_token = openssl_random_pseudo_bytes($len);
+		$random_string = base64_encode($rand_token);
 
 		return $random_string;
 	}

--- a/persistent_login.php
+++ b/persistent_login.php
@@ -408,7 +408,7 @@ class persistent_login extends rcube_plugin
 	function generate_random_token($len = 32)
 	{
 		$random_token  = openssl_random_pseudo_bytes($len);
-		$encoded_token = base64_encode($rand_token);
+		$encoded_token = base64_encode($random_token);
 		$random_string = str_replace(array('/', '+', '='), array('~', '_', ''), $encoded_token);
 
 		return $random_string;

--- a/persistent_login.php
+++ b/persistent_login.php
@@ -409,7 +409,7 @@ class persistent_login extends rcube_plugin
 	{
 		$random_token  = openssl_random_pseudo_bytes($len);
 		$encoded_token = base64_encode($rand_token);
-		$random_string = str_replace(array('/', '+', '='), array('~', '_', '.'), $encoded_token);
+		$random_string = str_replace(array('/', '+', '='), array('~', '_', ''), $encoded_token);
 
 		return $random_string;
 	}

--- a/persistent_login.php
+++ b/persistent_login.php
@@ -407,8 +407,9 @@ class persistent_login extends rcube_plugin
 	 */
 	function generate_random_token($len = 32)
 	{
-		$rand_token = openssl_random_pseudo_bytes($len);
-		$random_string = base64_encode($rand_token);
+		$random_token  = openssl_random_pseudo_bytes($len);
+		$encoded_token = base64_encode($rand_token);
+		$random_string = str_replace(array('/', '+', '='), array('~', '_', '.'), $encoded_token);
 
 		return $random_string;
 	}


### PR DESCRIPTION
The current version of 'generate_random_token' can be improved on speed and security.

1) 32 bytes is considered secure enough for tokens nowadays
2) calling 62 times the not so secure 'mt_rand' function is rather inefficient and likely still less predictable than using once 'openssl_random_pseudo_bytes'
3) forcing the token to be always 28 bytes long , omits 10% of the random generated token.  (a random number below 100 which is always 2 digits, omits 0 to 9)