### PR TITLE
Add dark mode support for warning message

### DIFF
--- a/persistent_login.css
+++ b/persistent_login.css
@@ -26,3 +26,8 @@
 	text-align: left;
 	text-shadow: none;
 }
+
+html.dark-mode .ifpl-hint {
+        background: none;
+        color: #f00;
+}


### PR DESCRIPTION
Removes background and ups saturation of text for dark mode, fixes #62
![image](https://user-images.githubusercontent.com/9071443/197774311-032776c7-16f9-4284-b903-5c2a70239285.png)
